### PR TITLE
feat: rename job and update repositories in workflow

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 jobs:
-  universal-addon:
+  helm-chart-template:
     if: github.repository != 'lablabs/helm-chart-template'
     runs-on: ubuntu-24.04
     steps:
@@ -18,7 +18,7 @@ jobs:
         with:
           app-id: ${{ secrets.LARA_TEMPLATE_SYNC_APP_ID }}
           private-key: ${{ secrets.LARA_TEMPLATE_SYNC_APP_PRIVATE_KEY }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: helm-chart-template,${{ github.event.repository.name }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
           token: ${{ steps.template-sync-app-token.outputs.token }} # needed for private repositories
           persist-credentials: false
 
-      - name: Sync universal-addon template
+      - name: Sync helm-chart-template template
         uses: AndreasAugustin/actions-template-sync@8ec19a5f2721ffb81ff809aa340ddf75e6a85ea6 # v2.5.2
         with:
           source_gh_token: ${{ steps.template-sync-app-token.outputs.token }}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

This pull request updates the GitHub Actions workflow in `.github/workflows/template-sync.yaml` to switch from syncing the `universal-addon` template to syncing the `helm-chart-template` template. The changes ensure that the correct template is referenced and synced for repositories using this workflow.

**Workflow template update:**

* The job name in the workflow was changed from `universal-addon` to `helm-chart-template`, updating all related identifiers to match the new template name.
* The list of repositories to sync now explicitly includes both `helm-chart-template` and the current repository, ensuring the workflow targets the intended templates.
* The step name for syncing the template was updated to reference `helm-chart-template` instead of `universal-addon`, clarifying the workflow's purpose.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

https://github.com/lablabs/keeper/actions/runs/19165138760
